### PR TITLE
Single queryString deletion issue fixed

### DIFF
--- a/qurl.js
+++ b/qurl.js
@@ -82,7 +82,7 @@
 
     queryString = setParamsStringFromObject(params);
 
-    if (this.updateHistory && queryString) {
+    if (this.updateHistory) {
       this.go(queryString);
     }
   };

--- a/qurl.js
+++ b/qurl.js
@@ -89,6 +89,9 @@
 
   Qurl.prototype.removeAll = function () {
     this.queryString = setParamsStringFromObject({}, true);
+    if (this.updateHistory) {
+        this.go(this.queryString);
+    }
   };
 
   Qurl.prototype.toString = function () {


### PR DESCRIPTION
Whatever the queryString be, needs to be updated after deletion. If not, at least one queryString sticks doesn't get updated.